### PR TITLE
x86_64: Fix for AMD SME issue

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -6198,6 +6198,7 @@ struct machine_specific {
 	ulong cpu_entry_area_end;
 	ulong page_offset_force;
 	char **exception_functions;
+	ulong sme_mask;
 };
 
 #define KSYMS_START    (0x1)


### PR DESCRIPTION
Kernel commit changes(see [1]/[2]) may cause the failure of crash-utility
with the following error:

  #./crash /home/vmlinux /home/vmcore
  ...
  For help, type "help".
  Type "apropos word" to search for commands related to "word"...

  crash: seek error: physical address: 8000760a14000  type: "p4d page"

Let's get the "NUMBER(sme_mask)" from vmcoreinfo, and try to remove
the C-bit from the page table entries, the intention is to get the
true physical address.

Related kernel commits:
[1] aad983913d77 ("x86/mm/encrypt: Simplify sme_populate_pgd() and sme_populate_pgd_large()")
[2] e7d445ab26db ("x86/sme: Use #define USE_EARLY_PGTABLE_L5 in mem_encrypt_identity.c")

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>