### PR TITLE
ps: Provide an option to display no header line

### DIFF
--- a/help.c
+++ b/help.c
@@ -1379,7 +1379,7 @@ NULL
 char *help_ps[] = {
 "ps",
 "display process status information",
-"[-k|-u|-G|-y policy] [-s] [-p|-c|-t|-[l|m][-C cpu]|-a|-g|-r|-S|-A]\n     [pid | task | command] ...",
+"[-k|-u|-G|-y policy] [-s] [-p|-c|-t|-[l|m][-C cpu]|-a|-g|-r|-S|-A|-H]\n     [pid | task | command] ...",
 "  This command displays process status for selected, or all, processes" ,
 "  in the system.  If no arguments are entered, the process data is",
 "  is displayed for all processes.  Specific processes may be selected",
@@ -1458,6 +1458,7 @@ char *help_ps[] = {
 "       -r  display resource limits (rlimits) of selected, or all, tasks.",
 "       -S  display a summary consisting of the number of tasks in a task state.",
 "       -A  display only the active task on each cpu.",
+"       -H  display no header line.",
 "\nEXAMPLES",
 "  Show the process status of all current tasks:\n",
 "    %s> ps",

--- a/task.c
+++ b/task.c
@@ -3504,7 +3504,7 @@ cmd_ps(void)
 	cpuspec = NULL;
 	flag = 0;
 
-        while ((c = getopt(argcnt, args, "ASgstcpkuGlmarC:y:")) != EOF) {
+        while ((c = getopt(argcnt, args, "HASgstcpkuGlmarC:y:")) != EOF) {
                 switch(c)
 		{
 		case 'k':
@@ -3613,6 +3613,10 @@ cmd_ps(void)
 		case 'A':
 			check_ps_exclusive(flag, PS_ACTIVE);
 			flag |= PS_ACTIVE;
+			break;
+
+		case 'H':
+			flag |= PS_NO_HEADER;
 			break;
 
 		default:


### PR DESCRIPTION
One might often find it useful to redirect/or filter the output generated by the 'ps' command. This simple patch provides an option (i.e. '-H') to display no header line so it does not need to be considered e.g.

crash> ps -u -H | head -5
        1       0   1  ffff956e8028d280  IN   0.0   174276     9272  systemd
     1067       1   2  ffff956e81380000  IN   0.1    59480    15788  systemd-journal
     1080       1   0  ffff956e8d152940  IN   0.0    36196     3548  systemd-udevd
     1278       1   6  ffff956e8aa60000  IN   0.0    17664     3072  systemd-oomd
     1366       1   7  ffff956e88548000  IN   0.0    10868     2328  dbus-broker-lau

Signed-off-by: Aaron Tomlin <atomlin@atomlin.com>