### PR TITLE
Fix for "bt" command printing "bogus exception frame" warning

### DIFF
--- a/x86_64.c
+++ b/x86_64.c
@@ -3938,6 +3938,11 @@ in_exception_stack:
         if (irq_eframe) {
                 bt->flags |= BT_EXCEPTION_FRAME;
                 i = (irq_eframe - bt->stackbase)/sizeof(ulong);
+                if (symbol_exists("asm_common_interrupt")) {
+			i -= 1;
+			up = (ulong *)(&bt->stackbuf[i*sizeof(ulong)]);
+			bt->instptr = *up;
+                }
                 x86_64_print_stack_entry(bt, ofp, level, i, bt->instptr);
                 bt->flags &= ~(ulonglong)BT_EXCEPTION_FRAME;
                 cs = x86_64_exception_frame(EFRAME_PRINT|EFRAME_CS, 0, 
@@ -6520,6 +6525,14 @@ x86_64_irq_eframe_link_init(void)
 		machdep->machspec->irq_eframe_link = 0;
 	else
 		return; 
+
+	if (symbol_exists("asm_common_interrupt")) {
+		if (symbol_exists("asm_call_on_stack"))
+			machdep->machspec->irq_eframe_link = -64;
+		else
+			machdep->machspec->irq_eframe_link = -32;
+		return;
+	}
 
 	if (THIS_KERNEL_VERSION < LINUX(2,6,9)) 
 		return;


### PR DESCRIPTION
Currently, the "bt" command may print a bogus exception frame and the remaining frame will be truncated on x86_64 when using the "virsh send-key <kvm guest> KEY_LEFTALT KEY_SYSRQ KEY_C" command to trigger a panic from the KVM host. For example:

  crash> bt
  PID: 0        TASK: ffff9e7a47e32f00  CPU: 3    COMMAND: "swapper/3"
   #0 [ffffba7900118bb8] machine_kexec at ffffffff87e5c2c7
   #1 [ffffba7900118c08] __crash_kexec at ffffffff87f9500d
   #2 [ffffba7900118cd0] panic at ffffffff87edfff9
   #3 [ffffba7900118d50] sysrq_handle_crash at ffffffff883ce2c1
   ...
   #16 [ffffba7900118fd8] handle_edge_irq at ffffffff87f559f2
   #17 [ffffba7900118ff0] asm_call_on_stack at ffffffff88800fa2
   --- <IRQ stack> ---
   #18 [ffffba790008bda0] asm_call_on_stack at ffffffff88800fa2
       RIP: ffffffffffffffff  RSP: 0000000000000124  RFLAGS: 00000003
       RAX: 0000000000000000  RBX: 0000000000000001  RCX: 0000000000000000
       RDX: ffffffff88800c1e  RSI: 0000000000000000  RDI: 0000000000000000
       RBP: 0000000000000001   R8: 0000000000000000   R9: 0000000000000000
       R10: 0000000000000000  R11: ffffffff88760555  R12: ffffba790008be08
       R13: ffffffff87f18002  R14: ffff9e7a47e32f00  R15: ffff9e7bb6198e00
       ORIG_RAX: 0000000000000000  CS: 0003  SS: 0000
  bt: WARNING: possibly bogus exception frame
  crash>

The following related kernel commits cause the current issue, crash needs to adjust the value of irq_eframe_link.

Related kernel commits:
[1] v5.8: 931b94145981 ("x86/entry: Provide helpers for executing on the irqstack") [2] v5.8: fa5e5c409213 ("x86/entry: Use idtentry for interrupts") [3] v5.12: 52d743f3b712 ("x86/softirq: Remove indirection in do_softirq_own_stack()")

Signed-off-by: Lianbo Jiang <lijiang@redhat.com>
Signed-off-by: Kazuhito Hagio <k-hagio-ab@nec.com>